### PR TITLE
runLightningTests configfile parameter as optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ making it part of the SFDX project.
 
 * _configFile_
 
-  The path to a test configuration file to configure WebDriver and other settings.
+  Optional. The path to a test configuration file to configure WebDriver and other settings.
   There isn't much official documentation on this; this
   [Salesforce Stackexchange answer](https://salesforce.stackexchange.com/questions/200451/how-to-run-lightning-test-service-lts-from-jenkins-hosted-on-aws-against-e-g)  provides some information. An example file is:
   ```

--- a/vars/runLightningTests.groovy
+++ b/vars/runLightningTests.groovy
@@ -5,7 +5,7 @@ def call(Map parameters = [:]) {
 
     Org org = (Org) parameters.org
     String appName = parameters.appName
-    String configFile = parameters.configFile
+    String configFile = parameters.configFile ? "--configfile ${parameters.configFile}" : ''
 
     // Separate tests by build number and org name
     def testResultsDir = "${env.WORKSPACE}/tests/lightning/${env.BUILD_NUMBER}/${org.name}"
@@ -15,7 +15,7 @@ def call(Map parameters = [:]) {
 
     echo "Running lightning tests for ${org.name} outputting to ${testResultsDir}"
 
-    sh returnStatus: true, script: "sfdx force:lightning:test:run --configfile ${configFile} --targetusername ${org.username} --resultformat tap --appname ${appName} --outputdir ${testResultsDir}"
+    sh returnStatus: true, script: "sfdx force:lightning:test:run ${configFile} --targetusername ${org.username} --resultformat tap --appname ${appName} --outputdir ${testResultsDir}"
     
     // Prefix class name with target org and app name to separate the test results
     sh "sed -i -- 's/classname=\"/classname=\"${org.name}.${appName}/g' ${testResultsDir}/*-junit.xml"


### PR DESCRIPTION
RunLightningTest has been changed to accept the configFile as optional.
(https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_force_lightning.htm)