### PR TITLE
Replace unsupported JSON reader with pipeline built-in implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,7 +474,7 @@ It might look like this:
 
 Typically not directly used as this is a building block for other steps.
 
-[Runs a shell command](vars/shWithResult.groovy) assumed to be an SFDX command that produces JSON output (typically via the `--json` argument), checks if the result is 0 (if it is not then it fails), and parses the output using [JsonSlurperClassic](http://docs.groovy-lang.org/latest/html/api/groovy/json/JsonSlurperClassic.html) library, returning the result object.
+[Runs a shell command](vars/shWithResult.groovy) assumed to be an SFDX command that produces JSON output (typically via the `--json` argument), checks if the result is 0 (if it is not then it fails), and parses the output using [readJSON](https://jenkins.io/doc/pipeline/steps/pipeline-utility-steps/#readjson-read-json-from-files-in-the-workspace) step, returning the result object.
 
 <a name="shWithStatus"></a>
 ### shWithStatus

--- a/vars/shWithResult.groovy
+++ b/vars/shWithResult.groovy
@@ -5,7 +5,7 @@ def call(script) {
     echo "Script ${script}"
     
     def json = sh returnStdout: true, script: script
-    def object = new groovy.json.JsonSlurperClassic().parseText(json);
+    def object = readJSON text: json
     if (object.status != 0) {
         error "Script ${scriptText} failed: status ${object.status} message: ${object.message} json: ${json}"
     }


### PR DESCRIPTION
Removing JsonSluperClassic given Jenkins has a built-in implementation and given this is [**not** supported by Jenkins](https://github.com/jenkinsci/script-security-plugin/pull/77), also mentioned [here](https://github.com/jenkinsci/script-security-plugin/pull/98).

This will also help on new installations given people won't have to approve JsonSlurperClassic.