### PR TITLE
Update retrieveExternals.groovy

### DIFF
--- a/vars/retrieveExternals.groovy
+++ b/vars/retrieveExternals.groovy
@@ -8,6 +8,12 @@ def call() {
     
     // Make Git externals optional
     if (exists) {
+        // Clear cache folder used by git-externals given it expects empty repositories
+        dir (".git_externals") {
+            echo "Clear git externals cache folder"
+            deleteDir()
+        }
+        
         sshagent (credentials: [env.GITHUB_CREDENTIAL_ID]) {
             // Want to throw away the noisy output; TODO ${jenkins_private_key} here?
             sh returnStdout:true, script: '''


### PR DESCRIPTION
Fix git externals problems with non-empty cache folder.

This fixes the problem when builds fail or workspaces are kept and git externals are meant to be updated but currently, they silently failed.

Reference in git-externals [README.md "Git externals update ... freshly cloned Git repository"](https://github.com/develersrl/git-externals)