### PR TITLE
Add ability to run LWC Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   * [runApexTests](#runApexTests)
   * [runLint](#runLint)
   * [runLightningTests](#runLightningTests)
+  * [runLwcTests](#runLwcTests)
   * [shWithResult](#shWithResult)
   * [shWithStatus](#shWithStatus)
   * [withOrgsInParallel](#withOrgsInParallel)
@@ -493,6 +494,24 @@ making it part of the SFDX project.
       }
   }
   ```
+<a name="runLwcTests"></a>
+### runLwcTests
+[Runs Lightning Web Components](vars/runLwcTests.groovy) for an org, puts the result in a unique folder and request junit to collect the results.
+
+As part of the process it installs the LWC Test Runner for Jest.
+
+**The jest-junit reporter must be present on devDependencies**:
+  ```javascript
+  "devDependencies": {
+    "@salesforce/sfdx-lwc-jest": "^0.7.0",
+    "jest-junit": "^10.0.0"
+  }
+  ```
+  
+* _org_
+
+  Required. An instance of Org that has been populated by **createScratchOrg**.
+
 <a name="runLint"></a>
 ### runLint
 

--- a/README.md
+++ b/README.md
@@ -496,9 +496,11 @@ making it part of the SFDX project.
   ```
 <a name="runLwcTests"></a>
 ### runLwcTests
-[Runs Lightning Web Components](vars/runLwcTests.groovy) for an org, puts the result in a unique folder and request junit to collect the results.
+[Runs Lightning Web Components](vars/runLwcTests.groovy) for an org using [sfdx-lwc-jest](https://github.com/salesforce/sfdx-lwc-jest), puts the result in a unique folder and request junit to collect the results.
 
 As part of the process it installs the LWC Test Runner for Jest.
+
+This action expects tests to exist, currently looking for tests defined by [glob in Jest](https://jestjs.io/docs/en/configuration#testmatch-arraystring), otherwise it fails to execute.
 
 **The jest-junit reporter must be present on devDependencies**:
   ```javascript

--- a/vars/runLwcTests.groovy
+++ b/vars/runLwcTests.groovy
@@ -1,0 +1,25 @@
+#!/usr/bin/env groovy
+import com.claimvantage.sjsl.Org
+
+def call(Map parameters = [:]) {
+
+    Org org = (Org) parameters.org
+    
+    // Install LWC Test Runner
+    sh script: "sfdx force:lightning:lwc:test:setup"
+
+    // Leaving it on a separate folder for now
+    def testResultsFolder = "jest-tests/${env.BUILD_NUMBER}/${org.name}"
+    def testResultsFile = "test-result-lwc-junit.xml"
+    def testResultsPath = "${testResultsFolder}/${testResultsFile}"
+
+    // Run LWC tests - deliberately no status check so build doesn't fail immediately; klunky reporter option passing via environment variables
+    // Using -- -- because the jest command is two levels below the npm
+    sh returnStatus: true, script: "JEST_JUNIT_OUTPUT_DIR='${testResultsFolder}' JEST_JUNIT_OUTPUT_NAME='${testResultsFile}' npm run test:unit -- -- --ci --reporters=default --reporters=jest-junit --passWithNoTests"
+
+    // Prefix class name with target org to separate the test results
+    sh returnStatus: true, script: "sed -i -- 's/classname=\"/classname=\"${org.name}./g' ${testResultsPath}"
+
+    // Collect results
+    junit keepLongStdio: true, testResults: "${testResultsPath}"
+}

--- a/vars/runLwcTests.groovy
+++ b/vars/runLwcTests.groovy
@@ -15,7 +15,7 @@ def call(Map parameters = [:]) {
 
     // Run LWC tests - deliberately no status check so build doesn't fail immediately; klunky reporter option passing via environment variables
     // Using -- -- because the jest command is two levels below the npm
-    sh returnStatus: true, script: "JEST_JUNIT_OUTPUT_DIR='${testResultsFolder}' JEST_JUNIT_OUTPUT_NAME='${testResultsFile}' npm run test:unit -- -- --ci --reporters=default --reporters=jest-junit --passWithNoTests"
+    sh returnStatus: true, script: "JEST_JUNIT_OUTPUT_DIR='${testResultsFolder}' JEST_JUNIT_OUTPUT_NAME='${testResultsFile}' npm run test:unit -- -- --ci --reporters=default --reporters=jest-junit"
 
     // Prefix class name with target org to separate the test results
     sh returnStatus: true, script: "sed -i -- 's/classname=\"/classname=\"${org.name}./g' ${testResultsPath}"


### PR DESCRIPTION
I created this skeleton based on your previous work (this requires the latest SFDX).

I also created the project [lwcTestsPoc](https://github.com/claimvantage/lwcTestsPoc) (public), with a Jenkins build (private) to validate the functionality.

For now I'm using `npm run` to execute the tests but I created an [issue for SFDX](https://github.com/forcedotcom/cli/issues/315) and hopefully, soon this could be replaced by `sfdx force:lightning:lwc:test:run` to make it more consistent.