### PR TITLE
ForceOrgCreate timeout set to 10 min

### DIFF
--- a/vars/createScratchOrg.groovy
+++ b/vars/createScratchOrg.groovy
@@ -7,7 +7,7 @@ def call(Org org) {
     org.alias = "${env.JOB_NAME}"
 
     // Username identifies the org in later stages
-    def create = shWithResult "sfdx force:org:create --definitionfile ${org.projectScratchDefPath} --json --setdefaultusername --durationdays ${org.durationDays} --setalias \"${org.alias}\""
+    def create = shWithResult "sfdx force:org:create --definitionfile ${org.projectScratchDefPath} --json --setdefaultusername --durationdays ${org.durationDays} --setalias \"${org.alias}\" --wait 10"
     org.username = create.username
     org.orgId = create.orgId
 


### PR DESCRIPTION
In some cases, the scratch org creation is taking longer than expected and the error below happens:
Error: You may consider increasing the --wait parameter value to increase timeout.

I've defined a default timeout to 10 min.