### PR TITLE
Fix retro-compatibility issues for Help processing

### DIFF
--- a/src/com/claimvantage/sjsl/Help.groovy
+++ b/src/com/claimvantage/sjsl/Help.groovy
@@ -13,6 +13,10 @@ class Help implements Serializable {
     // For named args case
     Help() {
     }
+  
+    Help(String spaceKey, String rootPageId, String repository) {
+        this(spaceKey, rootPageId, repository, false, [])
+    }
 
     Help(String spaceKey, String rootPageId, String repository, String... helpFixerParams) {
         this(spaceKey, rootPageId, repository, false, helpFixerParams)

--- a/vars/processHelp.groovy
+++ b/vars/processHelp.groovy
@@ -49,6 +49,8 @@ def call(Map parameters = [:]) {
             }
 
             echo "... run fixer"
+            
+            def helpFixerParams = h.helpFixerParams ?: [];
 
             // Backslashes needed for $ that are not tokens inside all of this script
             // To update correctly the help is necessary to do
@@ -56,7 +58,7 @@ def call(Map parameters = [:]) {
             // 2) unzip -o optimizedHelp.zip -d ${h.repository}
             // in order to update the repository with deletions as well
             sh """
-            java -jar ${helpFixer} -s exportedHelp.zip -t optimizedHelp.zip -k ${h.spaceKey} ${h.helpFixerParams.join(' ')}
+            java -jar ${helpFixer} -s exportedHelp.zip -t optimizedHelp.zip -k ${h.spaceKey} ${helpFixerParams.join(' ')}
             if [ -d ${h.repository} ]; then rm -rf ${h.repository}; fi
             git clone git@github.com:claimvantage/${h.repository}.git
             rm -rf ${h.repository}/*


### PR DESCRIPTION
Fixes the retro-compatibility issues introduced while extending the processing of Help functionality.

This is done through two things:
* Re-introducing the Help constructor with 3 arguments that still in-use.
* Fixing possible Null-pointer Exception while processing help due to the fact that `helpFixerParams` has not been used/sent.