### PR TITLE
Deploy Pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 * [Prerequisites](#prerequisites)
 * [Pipelines](#pipelines)
   * [sfdxBuildPipeline](#sfdxBuildPipeline)
+  * [sfdxDeployPipeline](#sfdxDeployPipeline)
 * [Steps](#steps)
   * [createScratchOrg](#createScratchOrg)
   * [deleteScratchOrg](#deleteScratchOrg)
@@ -359,6 +360,19 @@ The named values available are:
   This is the number of seconds to delay before the next parallel set of steps is started. 
   The aim is to smooth out the load a little both on the Jenkins machine and at the Salesforce side
   by staggering the the execution of the parallel logic.
+
+<a name="sfdxDeployPipeline"></a>
+### sfdxDeployPipeline
+This is a [ready-made pipeline](vars/sfdxDeployPipeline.groovy) - **recommended** that you start with this - that runs these stages using both the steps listed in the [Steps](#steps) section below and standard steps:
+```groovy
+stage("Checkout") {...}     
+stage("Authenticate to org") {...}
+stage("Install packages") {...}                // Only runs if packages beans are defined
+stage("Install Unlocked Packages") {...}       // Only runs if unlockedPackages beans are defined
+stage("Install unpackaged code") {...}         // Only runs if unpackagedSourcePath is defined
+stage("Logout org")  {...}
+stage("Clean") {...}
+```
 
 <a name="steps"></a>
 ## Steps

--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ The named values available are:
 * _sfdxUrlCredentialId_
 
   The id of a credential stored on your Jenkins instance at Credential Storage (more info about [Using credentials in Jenkins](https://www.jenkins.io/doc/book/using/using-credentials/).
-  The file must be in the format defined by SFDX auth URL (used by [force:auth:sfdxurl:store](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_force_auth.htm)): "force://<refreshToken>@<instanceUrl>" or "force://<clientId>:<clientSecret>:<refreshToken>@<instanceUrl>".
+  The file must be in the format defined by SFDX auth URL (used by [force:auth:sfdxurl:store](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_force_auth.htm) ): "force://<refreshToken>@<instanceUrl>" or "force://<clientId>:<clientSecret>:<refreshToken>@<instanceUrl>".
 * _packages_
 
   Reference an array of a simple bean object that holds the values needed to install managed package versions. This happens BEFORE unlocked packages are installed or unpackage source are deployed and only if the version to be installed is higher than the current one installed. When left out, no package installation is done.
@@ -406,7 +406,8 @@ The named values available are:
   Reference an array of a simple bean object that holds the values neeed to install Unlocked Packages. This happens BEFORE npackage source are deployed. When left out, no package installation is done.
 * _unpackagedSourcePath_
 
-  A comma-separated string....
+  The path to the unpackaged source. This is not recommended approach any more because Unlocked Packages gives much better visibility and tracking.
+  You can specify a comma-separeted list and they will be used. When left out, no unpackage source will be deployed.
 
 <a name="steps"></a>
 ## Steps

--- a/README.md
+++ b/README.md
@@ -374,6 +374,40 @@ stage("Logout org")  {...}
 stage("Clean") {...}
 ```
 
+You can use it on pipeline definition like `Jenkinsfile-deploy`:
+```groovy
+@Library('sfdx-jenkins-shared-library')
+import com.claimvantage.sjsl.Package
+
+sfdxDeployPipeline(
+    sfdxUrlCredentialId: 'jeferson-winter21-sfdxurl',
+    packages: [
+        new Package('cve v19', env.'cve.package.password.v19')
+    ],
+    unlockedPackages: [
+         new Package('dreamhouse v1', env.'dreamhous.password.v1')
+    ],
+    unpackagedSourcePath: 'force-app'
+)
+```
+
+Note: Recommend using one build per environment, and using [Git Parameter plugin](https://plugins.jenkins.io/git-parameter/) to define the git tag to be deployed with very little effort - allowing the selection of git tag as parameter.
+
+The named values available are:
+* _sfdxUrlCredentialId_
+
+  The id of a credential stored on your Jenkins instance at Credential Storage (more info about [Using credentials in Jenkins](https://www.jenkins.io/doc/book/using/using-credentials/).
+  The file must be in the format defined by SFDX auth URL (used by [force:auth:sfdxurl:store](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_force_auth.htm)): "force://<refreshToken>@<instanceUrl>" or "force://<clientId>:<clientSecret>:<refreshToken>@<instanceUrl>".
+* _packages_
+
+  Reference an array of a simple bean object that holds the values needed to install managed package versions. This happens BEFORE unlocked packages are installed or unpackage source are deployed and only if the version to be installed is higher than the current one installed. When left out, no package installation is done.
+* _unlockedPackages_
+
+  Reference an array of a simple bean object that holds the values neeed to install Unlocked Packages. This happens BEFORE npackage source are deployed. When left out, no package installation is done.
+* _unpackagedSourcePath_
+
+  A comma-separated string....
+
 <a name="steps"></a>
 ## Steps
 

--- a/README.md
+++ b/README.md
@@ -396,8 +396,8 @@ Note: Recommend using one build per environment, and using [Git Parameter plugin
 The named values available are:
 * _sfdxUrlCredentialId_
 
-  Required. The id of a credential stored on your Jenkins instance at Credential Storage (more info about [Using credentials in Jenkins](https://www.jenkins.io/doc/book/using/using-credentials/).
-  The file must be in the format defined by SFDX auth URL (used by [force:auth:sfdxurl:store](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_force_auth.htm) ): "force://<refreshToken>@<instanceUrl>" or "force://<clientId>:<clientSecret>:<refreshToken>@<instanceUrl>".
+  Required. The id of a credential stored on your Jenkins instance at Credential Storage (more info about [Using credentials in Jenkins](https://www.jenkins.io/doc/book/using/using-credentials/)).
+  The file must be in the format defined by SFDX auth URL (used by [force:auth:sfdxurl:store](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_force_auth.htm)): "force://<refreshToken>@<instanceUrl>" or "force://<clientId>:<clientSecret>:<refreshToken>@<instanceUrl>".
 * _packages_
 
   Optional. Reference an array of a simple bean object that holds the values needed to install managed package versions. This happens BEFORE unlocked packages are installed or unpackage source are deployed and only if the version to be installed is higher than the current one installed. When left out, no package installation is done.

--- a/README.md
+++ b/README.md
@@ -396,17 +396,17 @@ Note: Recommend using one build per environment, and using [Git Parameter plugin
 The named values available are:
 * _sfdxUrlCredentialId_
 
-  The id of a credential stored on your Jenkins instance at Credential Storage (more info about [Using credentials in Jenkins](https://www.jenkins.io/doc/book/using/using-credentials/).
+  Required. The id of a credential stored on your Jenkins instance at Credential Storage (more info about [Using credentials in Jenkins](https://www.jenkins.io/doc/book/using/using-credentials/).
   The file must be in the format defined by SFDX auth URL (used by [force:auth:sfdxurl:store](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_force_auth.htm) ): "force://<refreshToken>@<instanceUrl>" or "force://<clientId>:<clientSecret>:<refreshToken>@<instanceUrl>".
 * _packages_
 
-  Reference an array of a simple bean object that holds the values needed to install managed package versions. This happens BEFORE unlocked packages are installed or unpackage source are deployed and only if the version to be installed is higher than the current one installed. When left out, no package installation is done.
+  Optional. Reference an array of a simple bean object that holds the values needed to install managed package versions. This happens BEFORE unlocked packages are installed or unpackage source are deployed and only if the version to be installed is higher than the current one installed. When left out, no package installation is done.
 * _unlockedPackages_
 
-  Reference an array of a simple bean object that holds the values neeed to install Unlocked Packages. This happens BEFORE npackage source are deployed. When left out, no package installation is done.
+  Optional. Reference an array of a simple bean object that holds the values neeed to install Unlocked Packages. This happens BEFORE npackage source are deployed. When left out, no package installation is done.
 * _unpackagedSourcePath_
 
-  The path to the unpackaged source. This is not recommended approach any more because Unlocked Packages gives much better visibility and tracking.
+  Optional. The path to the unpackaged source. This is not recommended approach any more because Unlocked Packages gives much better visibility and tracking.
   You can specify a comma-separeted list and they will be used. When left out, no unpackage source will be deployed.
 
 <a name="steps"></a>

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -12,7 +12,7 @@ def call(Map parameters = [:]) {
             
             // We don't want the same deployment to run multiple times at same time
             // We also want to make sure we don't starve the job queue (limiting job to run up to a certain time)
-            throttle {
+            throttle([]) {
                 timeout(time: 4, unit: 'HOURS') {
                     stage("Checkout") {
                         checkout(scm: scm)

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -5,6 +5,7 @@ def call(Map parameters = [:]) {
     def packagesToInstall = parameters.packagesToInstall ?: []
     def sfdxUrlCredentialId = parameters.sfdxUrlCredentialId
     def unlockedPackagesToInstall = parameters.unlockedPackagesToInstall ?: []
+    def unpackageSourcePathToInstall = parameters.unpackageSourcePathToInstall // comma-separated, at least for now
 
     def deploymentOrg = new Org()
 
@@ -69,10 +70,18 @@ def call(Map parameters = [:]) {
                         }
                     }
 
-                    stage("Install unmanaged code") {
-                        // TODO: define parameters.
-                        // TODO: consider if multiple folders are supported
-                        // sh "sfdx force:source:deploy --sourcepath ${DEPLOYDIR} --json --targetusername ${SF_ALIAS} --testlevel ${TEST_LEVEL}"
+                    stage("Install unpackaged code") {
+                        if (unpackageSourcePathToInstall) {
+                            echo("Paths specified: ${unpackageSourcePathToInstall}")
+                            // TODO: do we need to set test level?
+                            def authenticationResult = shWithResult(
+                                """sfdx force:source:deploy \
+                                    --sourcepath ${unpackageSourcePathToInstall} \
+                                    --targetusername="${deploymentOrg.username}" \
+                                    --wait=120 \
+                                    --json
+                                """)
+                        }
                     }
 
                     stage("Logout org") {

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -64,7 +64,7 @@ def call(Map parameters = [:]) {
                                         --targetusername="${deploymentOrg.username}" \
                                         --wait=120 \
                                         --json
-                                    """
+                                    """)
                             }
                         }
                     }

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -33,6 +33,7 @@ def call(Map parameters = [:]) {
                             deploymentOrg.username = authenticationResult.username
                             deploymentOrg.orgId = authenticationResult.orgId
                             deploymentOrg.instanceUrl = authenticationResult.instanceUrl
+                            echo("Successfully authorized ${authenticationResult.username} with org ID ${authenticationResult.orgId}")
                         }
                     }
                     stage("Install packages") {
@@ -42,8 +43,6 @@ def call(Map parameters = [:]) {
                             for (p in packagesToInstall) {
                                 if (shouldInstallPackage(packageVersionId: p.versionId, installedPackages: installedPackages)) {
                                     installPackage(org: deploymentOrg, package: p)
-                                } else {
-                                    echo "No"
                                 }
                             }
                         } else {

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -43,7 +43,7 @@ def call(Map parameters = [:]) {
                                 }
                             }
                         } else {
-                            echo "No packages to install."
+                            echo("No packages to install")
                         }
                     }
 
@@ -55,7 +55,7 @@ def call(Map parameters = [:]) {
                         // 4. Some options such as upgradetype only available for Unlocked Packages
                         if (unlockedPackagesToInstall) {
                             for (p in unlockedPackagesToInstall) {
-                                echo "Installing Unlocked Package: ${p.versionId}"
+                                echo("Installing Unlocked Package: ${p.versionId}")
                                 def authenticationResult = shWithResult(
                                     """sfdx force:package:install \
                                         --package="${p.versionId}" \
@@ -67,6 +67,8 @@ def call(Map parameters = [:]) {
                                         --json
                                     """)
                             }
+                        } else {
+                            echo("No Unlocked Packages to install")
                         }
                     }
 
@@ -76,11 +78,12 @@ def call(Map parameters = [:]) {
                             // TODO: do we need to set test level?
                             def authenticationResult = shWithResult(
                                 """sfdx force:source:deploy \
-                                    --sourcepath ${unpackageSourcePathToInstall} \
+                                    --sourcepath="${unpackageSourcePathToInstall}" \
                                     --targetusername="${deploymentOrg.username}" \
                                     --wait=120 \
                                     --json
                                 """)
+                            echo("Successfuly installed unpackaged code")
                         }
                     }
 
@@ -109,9 +112,9 @@ def shouldInstallPackage(Map parameters = [:]) {
     def installedVersion = installedPackages[packageNamespace]
 
     def result = isVersionPossibleToInstallMostRecent(versionPossibleToInstall, installedVersion)
-    echo """
+    echo("""
         Name: ${packageName}, Namespace: ${packageNamespace}
-        Version to Install ${versionPossibleToInstall} > Installed Version ${installedVersion} ? ${result}"""
+        Version to Install ${versionPossibleToInstall} > Installed Version ${installedVersion} ? ${result}""")
 
     return result
 }

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -1,0 +1,98 @@
+#!/usr/bin/env groovy
+
+def call(Map parameters = [:]) {
+    def packagesToInstall = parameters.packagesToInstall ?: []
+
+    pipeline {
+        node {
+            // We want to set some properties, such as parameters
+            // properties(
+            //     propertiesConfigured
+            // )
+            
+            // We don't want the same deployment to run multiple times at same time
+            // We also want to make sure we don't starve the job queue (limiting job to run up to a certain time)
+            throttle {
+                timeout(time: 4, unit: 'HOURS') {
+                    stage("Install packages") {
+                        // TODO: do we need to set targetusername??
+                        def installedPackagesResult = shWithResult("sfdx force:package:installed:list --json");
+
+                        for (p in packagesToInstall) {
+                            if (shouldInstallPackage(packageVersionId: 'cvb v19', installedPackages: installedPackagesResult)) {
+                                echo "Yes";
+                            } else {
+                                echo "No";
+                            }
+                        }
+                    }
+
+                    stage("Install unmanaged code") {
+                    }
+                }
+            }
+        }
+    }
+}
+
+def shouldInstallPackage(Map parameters = [:]) {
+    def packageVersionId = parameters.packageVersionId;
+    def versionPossibleToInstall = retrievePackageVersionString(packageVersionId);
+    def namespace = retrievePackage(packageVersionId);
+
+    def installedPackages = parameters.installedPackages;
+    for (p in installedPackages) {
+        if (p.SubscriberPackageNamespace == namespace) {
+            return versionPossibleToInstall > p.SubscriberPackageVersionNumber
+        }
+    }
+
+    // If not installed, should install
+    return true;
+}
+
+def retrievePackageVersionString(packageVersionId) {
+    def v = retrievePackageVersion(packageVersionId)
+    String result = "${v.MajorVersion}.${v.MinorVersion}.${v.PatchVersion}.{v.BuildNumber}"
+    return result
+}
+
+def retrievePackageVersion(packageVersionId) {
+    packageVersionId = retrieveSfdxAlias packageVersionId
+    def subscriberPackageVersion = shWithResult(
+        """ \
+        sfdx force:data:soql:query \
+        --json \
+        --usetoolingapi \
+        --query " \
+            SELECT Name, MajorVersion, MinorVersion, PatchVersion, BuildNumber, SubscriberPackageId
+            FROM SubscriberPackageVersion
+            WHERE Id = '${packageVersionId}'\"
+        """);
+    return subscriberPackageVersion.records[0]
+}
+
+// force:package:install accepts alias to install it, however currently there is no native way to get the package ID
+def retrieveSfdxAlias(versionId) {
+    def sfdxProject = 'sfdx-project.json'
+    if (fileExists("${sfdxProject}")) {
+        def data = readJSON(file:"${sfdxProject}")
+        def isVersionIdAliasSet = data['packageAliases'] != null && data['packageAliases']["${versionId}"]
+        return isVersionIdAliasSet ? data['packageAliases']["${versionId}"] : versionId
+    }
+    return versionId
+}
+
+def retrievePackage(packageVersionId) {
+    def p = retrievePackageVersion(packageVersionId);
+    def subscriberPackage = shWithResult """ \
+        sfdx force:data:soql:query \
+        --json \
+        --usetoolingapi \
+        --query " \
+            SELECT Name 
+            FROM SubscriberPackage 
+            WHERE Id = '${p.SubscriberPackageId}'\"
+    """
+    return subscriberPackage.records[0].Name
+}

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -5,7 +5,7 @@ def call(Map parameters = [:]) {
     def packagesToInstall = parameters.packagesToInstall ?: []
     // TODO: remove the default, using it for testing
     def sfdxUrlCredentialId = parameters.sfdxUrlCredentialId ?: 'jeferson-winter21-sfdxurl'
-    def jobInputParameters = parameters.jobInputParameters ?: []
+    def jobInputParameters = parameters.jobInputParameters
 
     def deploymentOrg = new Org()
 
@@ -15,9 +15,7 @@ def call(Map parameters = [:]) {
             def propertiesConfigured = []
             if (jobInputParameters) {
                 propertiesConfigured.push(
-                    parameters(
-                        jobInputParameters
-                    )
+                    jobInputParameters
                 )
             }
             properties(

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -49,7 +49,13 @@ def shouldInstallPackage(Map parameters = [:]) {
     def installedPackages = parameters.installedPackages
     def installedVersion = installedPackages[namespace]
 
-    return versionPossibleToInstall > installedVersion
+    def result = versionPossibleToInstall > installedVersion
+    echo """
+        Namespace ${namespace} \n
+        Installed Version ${installedVersion} > Version to Install ${versionPossibleToInstall}? ${result}
+    """
+
+    return result
 }
 
 def retrievePackageVersionString(packageVersionId) {

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -14,15 +14,18 @@ def call(Map parameters = [:]) {
             // We also want to make sure we don't starve the job queue (limiting job to run up to a certain time)
             throttle {
                 timeout(time: 4, unit: 'HOURS') {
+                    stage("Checkout") {
+                        checkout(scm: scm)
+                    }
                     stage("Install packages") {
                         // TODO: do we need to set targetusername??
-                        def installedPackagesResult = shWithResult("sfdx force:package:installed:list --json");
+                        def installedPackagesResult = shWithResult("sfdx force:package:installed:list --json")
 
                         for (p in packagesToInstall) {
                             if (shouldInstallPackage(packageVersionId: 'cvb v19', installedPackages: installedPackagesResult)) {
-                                echo "Yes";
+                                echo "Yes"
                             } else {
-                                echo "No";
+                                echo "No"
                             }
                         }
                     }
@@ -36,11 +39,11 @@ def call(Map parameters = [:]) {
 }
 
 def shouldInstallPackage(Map parameters = [:]) {
-    def packageVersionId = parameters.packageVersionId;
-    def versionPossibleToInstall = retrievePackageVersionString(packageVersionId);
-    def namespace = retrievePackage(packageVersionId);
+    def packageVersionId = parameters.packageVersionId
+    def versionPossibleToInstall = retrievePackageVersionString(packageVersionId)
+    def namespace = retrievePackage(packageVersionId)
 
-    def installedPackages = parameters.installedPackages;
+    def installedPackages = parameters.installedPackages
     for (p in installedPackages) {
         if (p.SubscriberPackageNamespace == namespace) {
             return versionPossibleToInstall > p.SubscriberPackageVersionNumber
@@ -48,7 +51,7 @@ def shouldInstallPackage(Map parameters = [:]) {
     }
 
     // If not installed, should install
-    return true;
+    return true
 }
 
 def retrievePackageVersionString(packageVersionId) {
@@ -68,7 +71,7 @@ def retrievePackageVersion(packageVersionId) {
             SELECT Name, MajorVersion, MinorVersion, PatchVersion, BuildNumber, SubscriberPackageId
             FROM SubscriberPackageVersion
             WHERE Id = '${packageVersionId}'\"
-        """);
+        """)
     return subscriberPackageVersion.records[0]
 }
 
@@ -84,7 +87,7 @@ def retrieveSfdxAlias(versionId) {
 }
 
 def retrievePackage(packageVersionId) {
-    def p = retrievePackageVersion(packageVersionId);
+    def p = retrievePackageVersion(packageVersionId)
     def subscriberPackage = shWithResult """ \
         sfdx force:data:soql:query \
         --json \

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -9,7 +9,7 @@ def call(Map parameters = [:]) {
 
     def deploymentOrg = new Org()
 
-    if (sfdxUrlCredentialId) {
+    if (!sfdxUrlCredentialId?.trim()) {
         error('Please specify a credential id on sfdxUrlCredentialId')
     }
 

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -2,6 +2,10 @@
 
 def call(Map parameters = [:]) {
     def packagesToInstall = parameters.packagesToInstall ?: []
+    // TODO: remove the default, using it for testing
+    def sfdxUrlCredentialId = parameters.sfdxUrlCredentialId ?: 'jeferson-winter21-sfdxurl'
+
+    def orgAlias = "${env.JOB_NAME}" 
 
     pipeline {
         node {
@@ -21,8 +25,8 @@ def call(Map parameters = [:]) {
                         // TODO: add argument for credential id(s).
                         // TODO: not sure if is better to check if needs to be authenticated, first.
                         // TODO: not sure if needs to set as the default user
-                        withCredentials([file(credentialsId: 'jeferson-winter21-sfdxurl', variable: 'SFDX_URL')]) {
-                            sh('sfdx force:auth:sfdxurl:store --setalias="JeffWinter21" --setdefaultusername --sfdxurlfile=$SFDX_URL')
+                        withCredentials([file(credentialsId: sfdxUrlCredentialId, variable: 'SFDX_URL')]) {
+                            sh('sfdx force:auth:sfdxurl:store --setalias="${orgAlias}" --setdefaultusername --sfdxurlfile=$SFDX_URL')
                         }
                     }
                     stage("Install packages") {

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -22,7 +22,7 @@ def call(Map parameters = [:]) {
                         // TODO: not sure if is better to check if needs to be authenticated, first.
                         // TODO: not sure if needs to set as the default user
                         withCredentials([file(credentialsId: 'jeferson-winter21-sfdxurl', variable: 'SFDX_URL')]) {
-                            sh('sfdx force:auth:sfdxurl:store --setalias="JeffWinter21" --setdefaultusername --sfdxurlfile=$SFDX_URL');
+                            sh('sfdx force:auth:sfdxurl:store --setalias="JeffWinter21" --setdefaultusername --sfdxurlfile=$SFDX_URL')
                         }
                     }
                     stage("Install packages") {

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -17,6 +17,14 @@ def call(Map parameters = [:]) {
                     stage("Checkout") {
                         checkout(scm: scm)
                     }
+                    stage("Authenticate") {
+                        // TODO: add argument for credential id(s).
+                        // TODO: not sure if is better to check if needs to be authenticated, first.
+                        // TODO: not sure if needs to set as the default user
+                        withCredentials([file(credentialsId: 'jeferson-winter21-sfdxurl', variable: 'SFDX_URL')]) {
+                            sh('sfdx force:auth:sfdxurl:store --setalias="JeffWinter21" --setdefaultusername --sfdxurlfile=$SFDX_URL');
+                        }
+                    }
                     stage("Install packages") {
                         if (packagesToInstall) {
                             def installedPackages = retrieveInstalledPackages()

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -18,16 +18,18 @@ def call(Map parameters = [:]) {
                         checkout(scm: scm)
                     }
                     stage("Install packages") {
-                        // TODO: do we need to set targetusername??
-                        // def installedPackagesResult = shWithResult("sfdx force:package:installed:list --json")
-                        def installedPackages = retrieveInstalledPackages()
+                        if (packagesToInstall) {
+                            def installedPackages = retrieveInstalledPackages()
 
-                        for (p in packagesToInstall) {
-                            if (shouldInstallPackage(packageVersionId: 'cvb v19', installedPackages: installedPackages)) {
-                                echo "Yes"
-                            } else {
-                                echo "No"
+                            for (p in packagesToInstall) {
+                                if (shouldInstallPackage(packageVersionId: 'cvb v19', installedPackages: installedPackages)) {
+                                    echo "Yes"
+                                } else {
+                                    echo "No"
+                                }
                             }
+                        } else {
+                            echo "No packages to install."
                         }
                     }
 
@@ -46,7 +48,7 @@ def shouldInstallPackage(Map parameters = [:]) {
 
     def installedPackages = parameters.installedPackages
     def installedVersion = installedPackages[namespace]
-    
+
     return versionPossibleToInstall > installedVersion
 }
 

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -67,6 +67,7 @@ def call(Map parameters = [:]) {
                                         --wait=120 \
                                         --json
                                     """)
+                                echo("Successfuly installed Unlocked Package")
                             }
                         } else {
                             echo("No Unlocked Packages to install")

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -13,7 +13,7 @@ def call(Map parameters = [:]) {
         node {
             // We want to set some properties, such as parameters
             def propertiesConfigured = []
-            propertiesConfigured.push(
+            propertiesConfigured.add(
                 parameters(
                     [
                         gitParameter(name: 'BRANCH_TAG', type: 'PT_BRANCH_TAG', defaultValue: 'master')

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -5,8 +5,6 @@ def call(Map parameters = [:]) {
     // TODO: remove the default, using it for testing
     def sfdxUrlCredentialId = parameters.sfdxUrlCredentialId ?: 'jeferson-winter21-sfdxurl'
 
-    def orgAlias = "${env.JOB_NAME}" 
-
     pipeline {
         node {
             // We want to set some properties, such as parameters
@@ -18,6 +16,8 @@ def call(Map parameters = [:]) {
             // We also want to make sure we don't starve the job queue (limiting job to run up to a certain time)
             throttle([]) {
                 timeout(time: 4, unit: 'HOURS') {
+                    def orgAlias = "${env.JOB_NAME}"
+
                     stage("Checkout") {
                         checkout(scm: scm)
                     }

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -22,7 +22,7 @@ def call(Map parameters = [:]) {
                             def installedPackages = retrieveInstalledPackages()
 
                             for (p in packagesToInstall) {
-                                if (shouldInstallPackage(packageVersionId: 'cvb v19', installedPackages: installedPackages)) {
+                                if (shouldInstallPackage(packageVersionId: p, installedPackages: installedPackages)) {
                                     echo "Yes"
                                 } else {
                                     echo "No"

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -56,6 +56,10 @@ def call(Map parameters = [:]) {
                         // sh "sfdx force:source:deploy --sourcepath ${DEPLOYDIR} --json --targetusername ${SF_ALIAS} --testlevel ${TEST_LEVEL}"
                     }
 
+                    stage("Logout org") {
+                        shWithStatus("sfdx force:auth:logout --noprompt --targetusername=${deploymentOrg.username}")
+                    }
+
                     stage("Clean") {
                         // Always remove workspace and don't fail the build for any errors
                         cleanWs notFailBuild: true

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -15,7 +15,11 @@ def call(Map parameters = [:]) {
             def propertiesConfigured = []
             if (jobInputParameters) {
                 propertiesConfigured.push(
-                    jobInputParameters
+                    parameters(
+                        [
+                            gitParameter(name: 'BRANCH_TAG', type: 'PT_BRANCH_TAG', defaultValue: 'master')
+                        ]
+                    )
                 )
             }
             properties(

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -13,11 +13,13 @@ def call(Map parameters = [:]) {
         node {
             // We want to set some properties, such as parameters
             def propertiesConfigured = []
-            propertiesConfigured.push(
-                parameters(
-                    jobInputParameters
+            if (jobInputParameters) {
+                propertiesConfigured.push(
+                    parameters(
+                        jobInputParameters
+                    )
                 )
-            )
+            }
             properties(
                 propertiesConfigured
             )

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -99,6 +99,7 @@ def retrievePackage(packageVersionId) {
 }
 
 def retrieveInstalledPackages() {
+    // Using Tooling API instead of sfdx force:package:installed:list due to Salesforce query timeout issues
     def installedPackagesResults = shWithResult """ \
         sfdx force:data:soql:query \
         --json \

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -44,14 +44,14 @@ def call(Map parameters = [:]) {
 def shouldInstallPackage(Map parameters = [:]) {
     def packageVersionId = parameters.packageVersionId
     def versionPossibleToInstall = retrievePackageVersionString(packageVersionId)
-    def namespace = retrievePackage(packageVersionId)
+    def packageDefinition = retrievePackage(packageVersionId)
 
     def installedPackages = parameters.installedPackages
     def installedVersion = installedPackages[namespace]
 
     def result = versionPossibleToInstall > installedVersion
     echo """
-        Namespace ${namespace} \n
+        Name: ${packageDefinition.Name}, Namespace ${packageDefinition.NamespacePrefix} \n
         Installed Version ${installedVersion} > Version to Install ${versionPossibleToInstall}? ${result}
     """
 
@@ -60,7 +60,7 @@ def shouldInstallPackage(Map parameters = [:]) {
 
 def retrievePackageVersionString(packageVersionId) {
     def v = retrievePackageVersion(packageVersionId)
-    String result = "${v.MajorVersion}.${v.MinorVersion}.${v.PatchVersion}.{v.BuildNumber}"
+    String result = "${v.MajorVersion}.${v.MinorVersion}.${v.PatchVersion}.${v.BuildNumber}"
     return result
 }
 
@@ -97,11 +97,11 @@ def retrievePackage(packageVersionId) {
         --json \
         --usetoolingapi \
         --query " \
-            SELECT Name 
+            SELECT Name, NamespacePrefix
             FROM SubscriberPackage 
             WHERE Id = '${p.SubscriberPackageId}'\"
     """
-    return subscriberPackage.records[0].Name
+    return subscriberPackage.records[0]
 }
 
 def retrieveInstalledPackages() {

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -16,7 +16,6 @@ def call(Map parameters = [:]) {
             // We also want to make sure we don't starve the job queue (limiting job to run up to a certain time)
             throttle([]) {
                 timeout(time: 4, unit: 'HOURS') {
-                    def orgAlias = "${env.JOB_NAME}"
 
                     stage("Checkout") {
                         checkout(scm: scm)
@@ -26,7 +25,7 @@ def call(Map parameters = [:]) {
                         // TODO: not sure if is better to check if needs to be authenticated, first.
                         // TODO: not sure if needs to set as the default user
                         withCredentials([file(credentialsId: sfdxUrlCredentialId, variable: 'SFDX_URL')]) {
-                            sh('sfdx force:auth:sfdxurl:store --setalias="$orgAlias" --setdefaultusername --sfdxurlfile=$SFDX_URL')
+                            sh('sfdx force:auth:sfdxurl:store --setalias="$JOB_NAME" --setdefaultusername --sfdxurlfile=$SFDX_URL')
                         }
                     }
                     stage("Install packages") {

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -45,13 +45,15 @@ def shouldInstallPackage(Map parameters = [:]) {
     def packageVersionId = parameters.packageVersionId
     def versionPossibleToInstall = retrievePackageVersionString(packageVersionId)
     def packageDefinition = retrievePackage(packageVersionId)
+    def packageNamespace = packageDefinition.NamespacePrefix
+    def packageName = packageDefinition.Name
 
     def installedPackages = parameters.installedPackages
-    def installedVersion = installedPackages[namespace]
+    def installedVersion = installedPackages[packageNamespace]
 
     def result = versionPossibleToInstall > installedVersion
     echo """
-        Name: ${packageDefinition.Name}, Namespace ${packageDefinition.NamespacePrefix} \n
+        Name: ${packageName}, Namespace ${packageNamespace} \n
         Installed Version ${installedVersion} > Version to Install ${versionPossibleToInstall}? ${result}
     """
 

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -9,6 +9,10 @@ def call(Map parameters = [:]) {
 
     def deploymentOrg = new Org()
 
+    if (sfdxUrlCredentialId) {
+        error('Please specify a credential id on sfdxUrlCredentialId')
+    }
+
     pipeline {
         node {
             

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -12,16 +12,14 @@ def call(Map parameters = [:]) {
     pipeline {
         node {
             // We want to set some properties, such as parameters
-            def propertiesConfigured = []
-            propertiesConfigured.add(
-                parameters(
-                    [
-                        gitParameter(name: 'BRANCH_TAG', type: 'PT_BRANCH_TAG', defaultValue: 'master')
-                    ]
-                )
-            )
             properties(
-                propertiesConfigured
+                [
+                    parameters(
+                        [
+                            gitParameter(name: 'BRANCH_TAG', type: 'PT_BRANCH_TAG', defaultValue: 'master')
+                        ]
+                    )
+                ]
             )
             
             // We don't want the same deployment to run multiple times at same time

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -21,9 +21,6 @@ def call(Map parameters = [:]) {
                         checkout(scm: scm)
                     }
                     stage("Authenticate to org") {
-                        // TODO: add argument for credential id(s).
-                        // TODO: not sure if is better to check if needs to be authenticated, first.
-                        // TODO: not sure if needs to set as the default user
                         withCredentials([file(credentialsId: sfdxUrlCredentialId, variable: 'SFDX_URL')]) {
                             def authenticationResult = shWithResult('sfdx force:auth:sfdxurl:store --setalias="$JOB_NAME" --setdefaultusername --sfdxurlfile=$SFDX_URL --json')
                             deploymentOrg.alias = "${env.JOB_NAME}"

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -52,7 +52,6 @@ def call(Map parameters = [:]) {
 
                     stage("Clean") {
                         // Always remove workspace and don't fail the build for any errors
-                        echo "Deleting workspace ${env.WORKSPACE}"
                         cleanWs notFailBuild: true
                     }
                 }

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -5,22 +5,11 @@ def call(Map parameters = [:]) {
     def packagesToInstall = parameters.packagesToInstall ?: []
     // TODO: remove the default, using it for testing
     def sfdxUrlCredentialId = parameters.sfdxUrlCredentialId ?: 'jeferson-winter21-sfdxurl'
-    def jobInputParameters = parameters.jobInputParameters
 
     def deploymentOrg = new Org()
 
     pipeline {
         node {
-            // We want to set some properties, such as parameters
-            properties(
-                [
-                    parameters(
-                        [
-                            gitParameter(name: 'BRANCH_TAG', type: 'PT_BRANCH_TAG', defaultValue: 'master')
-                        ]
-                    )
-                ]
-            )
             
             // We don't want the same deployment to run multiple times at same time
             // We also want to make sure we don't starve the job queue (limiting job to run up to a certain time)

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -5,6 +5,11 @@ def call(Map parameters = [:]) {
     // TODO: remove the default, using it for testing
     def sfdxUrlCredentialId = parameters.sfdxUrlCredentialId ?: 'jeferson-winter21-sfdxurl'
 
+    // Using alias and username the same to make this potentially more dynamic
+    def deploymentOrg = new Org()
+    deploymentOrg.alias = "${env.JOB_NAME}"
+    deploymentOrg.username = deploymentOrg.alias
+
     pipeline {
         node {
             // We want to set some properties, such as parameters
@@ -34,7 +39,7 @@ def call(Map parameters = [:]) {
 
                             for (p in packagesToInstall) {
                                 if (shouldInstallPackage(packageVersionId: p.versionId, installedPackages: installedPackages)) {
-                                    echo "Yes"
+                                    installPackage(org: deploymentOrg, package: p)
                                 } else {
                                     echo "No"
                                 }

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -12,9 +12,11 @@ def call(Map parameters = [:]) {
     pipeline {
         node {
             // We want to set some properties, such as parameters
-            def propertiesConfigured = [
-                jobInputParameters
-            ]
+            propertiesConfigured.push(
+                parameters(
+                    jobInputParameters
+                )
+            )
             properties(
                 propertiesConfigured
             )

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -76,7 +76,8 @@ def shouldInstallPackage(Map parameters = [:]) {
     def installedPackages = parameters.installedPackages
     def installedVersion = installedPackages[packageNamespace]
 
-    def result = versionPossibleToInstall > installedVersion
+    // We don't want to keep re-installing
+    def result = installedVersion == versionPossibleToInstall ? false : mostRecentVersion([installedVersion, versionPossibleToInstall]) == versionPossibleToInstall
     echo """
         Name: ${packageName}, Namespace: ${packageNamespace}
         Installed Version ${installedVersion} > Version to Install ${versionPossibleToInstall}? ${result}"""
@@ -155,4 +156,29 @@ def retrieveInstalledPackages() {
     }
     
     return installedPackages
+}
+
+def String mostRecentVersion(List versions) {
+    def sorted = versions.sort(false) { a, b ->
+        List verA = a.tokenize('.')
+        List verB = b.tokenize('.')
+
+        def commonIndices = Math.min(verA.size(), verB.size())
+
+        for (int i = 0; i < commonIndices; ++i) {
+            def numA = verA[i].toInteger()
+            def numB = verB[i].toInteger()
+            echo("comparing $numA and $numB")
+
+            if (numA != numB) {
+                return numA <=> numB
+            }
+        }
+
+        // If we got this far then all the common indices are identical, so whichever version is longer must be more recent
+        verA.size() <=> verB.size()
+    }
+
+    echo("sorted versions: $sorted")
+    sorted[-1]
 }

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -30,7 +30,7 @@ def call(Map parameters = [:]) {
                             def installedPackages = retrieveInstalledPackages()
 
                             for (p in packagesToInstall) {
-                                if (shouldInstallPackage(packageVersionId: p, installedPackages: installedPackages)) {
+                                if (shouldInstallPackage(packageVersionId: p.versionId, installedPackages: installedPackages)) {
                                     echo "Yes"
                                 } else {
                                     echo "No"
@@ -42,6 +42,9 @@ def call(Map parameters = [:]) {
                     }
 
                     stage("Install unmanaged code") {
+                        // TODO: define parameters.
+                        // TODO: consider if multiple folders are supported
+                        // sh "sfdx force:source:deploy --sourcepath ${DEPLOYDIR} --json --targetusername ${SF_ALIAS} --testlevel ${TEST_LEVEL}"
                     }
                 }
             }

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -5,15 +5,19 @@ def call(Map parameters = [:]) {
     def packagesToInstall = parameters.packagesToInstall ?: []
     // TODO: remove the default, using it for testing
     def sfdxUrlCredentialId = parameters.sfdxUrlCredentialId ?: 'jeferson-winter21-sfdxurl'
+    def jobInputParameters = parameters.jobInputParameters ?: []
 
     def deploymentOrg = new Org()
 
     pipeline {
         node {
             // We want to set some properties, such as parameters
-            // properties(
-            //     propertiesConfigured
-            // )
+            def propertiesConfigured = [
+                jobInputParameters
+            ]
+            properties(
+                propertiesConfigured
+            )
             
             // We don't want the same deployment to run multiple times at same time
             // We also want to make sure we don't starve the job queue (limiting job to run up to a certain time)
@@ -23,7 +27,7 @@ def call(Map parameters = [:]) {
                     stage("Checkout") {
                         checkout(scm: scm)
                     }
-                    stage("Authenticate") {
+                    stage("Authenticate to org") {
                         // TODO: add argument for credential id(s).
                         // TODO: not sure if is better to check if needs to be authenticated, first.
                         // TODO: not sure if needs to set as the default user

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -52,7 +52,8 @@ def shouldInstallPackage(Map parameters = [:]) {
     def installedVersion = installedPackages[packageNamespace]
 
     def result = versionPossibleToInstall > installedVersion
-    echo """Name: ${packageName}, Namespace: ${packageNamespace} \n
+    echo """
+        Name: ${packageName}, Namespace: ${packageNamespace}
         Installed Version ${installedVersion} > Version to Install ${versionPossibleToInstall}? ${result}"""
 
     return result

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -52,10 +52,8 @@ def shouldInstallPackage(Map parameters = [:]) {
     def installedVersion = installedPackages[packageNamespace]
 
     def result = versionPossibleToInstall > installedVersion
-    echo """
-        Name: ${packageName}, Namespace ${packageNamespace} \n
-        Installed Version ${installedVersion} > Version to Install ${versionPossibleToInstall}? ${result}
-    """
+    echo """Name: ${packageName}, Namespace: ${packageNamespace} \n
+        Installed Version ${installedVersion} > Version to Install ${versionPossibleToInstall}? ${result}"""
 
     return result
 }

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -202,7 +202,6 @@ def Boolean isVersionPossibleToInstallMostRecent(String versionPossibleToInstall
     for (int i = 0; i < commonIndices; ++i) {
         def numA = verA[i].toInteger()
         def numB = verB[i].toInteger()
-        // println("comparing $numA and $numB")
 
         if (numA != numB) {
             return numA > numB

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -1,4 +1,5 @@
 #!/usr/bin/env groovy
+import com.claimvantage.sjsl.Org
 
 def call(Map parameters = [:]) {
     def packagesToInstall = parameters.packagesToInstall ?: []

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -3,8 +3,7 @@ import com.claimvantage.sjsl.Org
 
 def call(Map parameters = [:]) {
     def packagesToInstall = parameters.packagesToInstall ?: []
-    // TODO: remove the default, using it for testing
-    def sfdxUrlCredentialId = parameters.sfdxUrlCredentialId ?: 'jeferson-winter21-sfdxurl'
+    def sfdxUrlCredentialId = parameters.sfdxUrlCredentialId
 
     def deploymentOrg = new Org()
 

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -79,7 +79,7 @@ def shouldInstallPackage(Map parameters = [:]) {
     def result = isVersionPossibleToInstallMostRecent(versionPossibleToInstall, installedVersion)
     echo """
         Name: ${packageName}, Namespace: ${packageNamespace}
-        Installed Version ${installedVersion} > Version to Install ${versionPossibleToInstall}? ${result}"""
+        Version to Install ${versionPossibleToInstall} > Installed Version ${installedVersion} ? ${result}"""
 
     return result
 }

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -26,7 +26,7 @@ def call(Map parameters = [:]) {
                         // TODO: not sure if is better to check if needs to be authenticated, first.
                         // TODO: not sure if needs to set as the default user
                         withCredentials([file(credentialsId: sfdxUrlCredentialId, variable: 'SFDX_URL')]) {
-                            sh('sfdx force:auth:sfdxurl:store --setalias="${orgAlias}" --setdefaultusername --sfdxurlfile=$SFDX_URL')
+                            sh('sfdx force:auth:sfdxurl:store --setalias="$orgAlias" --setdefaultusername --sfdxurlfile=$SFDX_URL')
                         }
                     }
                     stage("Install packages") {

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -64,8 +64,8 @@ def retrievePackageVersionString(packageVersionId) {
     return result
 }
 
-def retrievePackageVersion(packageVersionId) {
-    packageVersionId = retrieveSfdxAlias packageVersionId
+def retrievePackageVersion(packageVersionIdOrAlias) {
+    def packageVersionId = retrieveSfdxAlias(packageVersionIdOrAlias)
     def subscriberPackageVersion = shWithResult(
         """ \
         sfdx force:data:soql:query \
@@ -80,14 +80,15 @@ def retrievePackageVersion(packageVersionId) {
 }
 
 // force:package:install accepts alias to install it, however currently there is no native way to get the package ID
-def retrieveSfdxAlias(versionId) {
+def retrieveSfdxAlias(packageVersionIdOrAlias) {
+    def packageVersionId = packageVersionIdOrAlias;
     def sfdxProject = 'sfdx-project.json'
     if (fileExists("${sfdxProject}")) {
         def data = readJSON(file:"${sfdxProject}")
-        def isVersionIdAliasSet = data['packageAliases'] != null && data['packageAliases']["${versionId}"]
-        return isVersionIdAliasSet ? data['packageAliases']["${versionId}"] : versionId
+        def isVersionIdAliasSet = data['packageAliases'] != null && data['packageAliases']["${packageVersionIdOrAlias}"]
+        packageVersionId = isVersionIdAliasSet ? data['packageAliases']["${packageVersionIdOrAlias}"] : packageVersionIdOrAlias
     }
-    return versionId
+    return packageVersionId
 }
 
 def retrievePackage(packageVersionId) {

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -13,15 +13,13 @@ def call(Map parameters = [:]) {
         node {
             // We want to set some properties, such as parameters
             def propertiesConfigured = []
-            if (jobInputParameters) {
-                propertiesConfigured.push(
-                    parameters(
-                        [
-                            gitParameter(name: 'BRANCH_TAG', type: 'PT_BRANCH_TAG', defaultValue: 'master')
-                        ]
-                    )
+            propertiesConfigured.push(
+                parameters(
+                    [
+                        gitParameter(name: 'BRANCH_TAG', type: 'PT_BRANCH_TAG', defaultValue: 'master')
+                    ]
                 )
-            }
+            )
             properties(
                 propertiesConfigured
             )

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -2,10 +2,10 @@
 import com.claimvantage.sjsl.Org
 
 def call(Map parameters = [:]) {
-    def packagesToInstall = parameters.packagesToInstall ?: []
+    def packagesToInstall = parameters.packages ?: []
     def sfdxUrlCredentialId = parameters.sfdxUrlCredentialId
-    def unlockedPackagesToInstall = parameters.unlockedPackagesToInstall ?: []
-    def unpackageSourcePathToInstall = parameters.unpackageSourcePathToInstall // comma-separated, at least for now
+    def unlockedPackagesToInstall = parameters.unlockedPackages ?: []
+    def unpackagedSourcePathToInstall = parameters.unpackagedSourcePath // comma-separated, at least for now
 
     def deploymentOrg = new Org()
 
@@ -70,12 +70,12 @@ def call(Map parameters = [:]) {
                     }
 
                     stage("Install unpackaged code") {
-                        if (unpackageSourcePathToInstall) {
-                            echo("Paths specified: ${unpackageSourcePathToInstall}")
+                        if (unpackagedSourcePathToInstall) {
+                            echo("Paths specified: ${unpackagedSourcePathToInstall}")
                             // TODO: do we need to set test level?
                             def authenticationResult = shWithResult(
                                 """sfdx force:source:deploy \
-                                    --sourcepath="${unpackageSourcePathToInstall}" \
+                                    --sourcepath="${unpackagedSourcePathToInstall}" \
                                     --targetusername="${deploymentOrg.username}" \
                                     --wait=120 \
                                     --json

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -12,6 +12,7 @@ def call(Map parameters = [:]) {
     pipeline {
         node {
             // We want to set some properties, such as parameters
+            def propertiesConfigured = []
             propertiesConfigured.push(
                 parameters(
                     jobInputParameters

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -170,6 +170,7 @@ def retrievePackage(packageVersionId) {
 
 def retrieveInstalledPackages() {
     // Using Tooling API instead of sfdx force:package:installed:list due to Salesforce query timeout issues
+    // https://trailblazer.salesforce.com/issues_view?id=a1p4V0000003wa2QAA
     def installedPackagesResults = shWithResult """ \
         sfdx force:data:soql:query \
         --json \

--- a/vars/sfdxDeployPipeline.groovy
+++ b/vars/sfdxDeployPipeline.groovy
@@ -46,6 +46,12 @@ def call(Map parameters = [:]) {
                         // TODO: consider if multiple folders are supported
                         // sh "sfdx force:source:deploy --sourcepath ${DEPLOYDIR} --json --targetusername ${SF_ALIAS} --testlevel ${TEST_LEVEL}"
                     }
+
+                    stage("Clean") {
+                        // Always remove workspace and don't fail the build for any errors
+                        echo "Deleting workspace ${env.WORKSPACE}"
+                        cleanWs notFailBuild: true
+                    }
                 }
             }
         }


### PR DESCRIPTION
This is related to #96 and allows the deployment to orgs, such as QA, UAT, Production, etc.
It is intended to be used separate to the Continuous Integration build and uses the long-lived org instead of creating scratch orgs.