### PR TITLE
bug/#103 Revert change due to impact on builds

### DIFF
--- a/vars/sfdxBuildPipeline.groovy
+++ b/vars/sfdxBuildPipeline.groovy
@@ -184,15 +184,15 @@ def call(Map parameters = [:]) {
                         }
                     }
                 }
-                
-                stage("publish") {
-                    echo "Publishing test results"
-                    junit keepLongStdio: true, testResults: 'tests/**/*-junit.xml'
-                }
             } catch (error) {
                 echo "Error: ${error}"
                 currentBuild.currentResult = 'FAILURE'
             } finally {
+
+                stage("publish") {
+                    echo "Publishing test results"
+                    junit keepLongStdio: true, testResults: 'tests/**/*-junit.xml'
+                }
                 
                 if (notificationChannel) {
                     stage("slack notification end") {

--- a/vars/sfdxBuildPipeline.groovy
+++ b/vars/sfdxBuildPipeline.groovy
@@ -184,9 +184,6 @@ def call(Map parameters = [:]) {
                         }
                     }
                 }
-            } catch (error) {
-                echo "Error: ${error}"
-                currentBuild.currentResult = 'FAILURE'
             } finally {
 
                 stage("publish") {

--- a/vars/sfdxBuildPipeline.groovy
+++ b/vars/sfdxBuildPipeline.groovy
@@ -75,7 +75,7 @@ def call(Map parameters = [:]) {
              * Using the try/catch block to ensure a safe cleanup, perform notifications 
              * and execute a final stage (optional)
              */
-            try {
+            // try {
                 def propertiesConfigured = []
                 propertiesConfigured.push(
                     buildDiscarder(
@@ -184,7 +184,7 @@ def call(Map parameters = [:]) {
                         }
                     }
                 }
-            } finally {
+            // } finally {
 
                 stage("publish") {
                     echo "Publishing test results"
@@ -238,7 +238,7 @@ def call(Map parameters = [:]) {
                         finalStage.call()
                     }
                 }
-            }
+            // }
         }
     }
 }

--- a/vars/sfdxBuildPipeline.groovy
+++ b/vars/sfdxBuildPipeline.groovy
@@ -189,8 +189,6 @@ def call(Map parameters = [:]) {
                     echo "Publishing test results"
                     junit keepLongStdio: true, testResults: 'tests/**/*-junit.xml'
                 }
-            } catch (error) {
-                echo "Error: ${error}"
             } finally {
                 
                 if (notificationChannel) {

--- a/vars/sfdxBuildPipeline.groovy
+++ b/vars/sfdxBuildPipeline.groovy
@@ -189,6 +189,9 @@ def call(Map parameters = [:]) {
                     echo "Publishing test results"
                     junit keepLongStdio: true, testResults: 'tests/**/*-junit.xml'
                 }
+            } catch (error) {
+                echo "Error: ${error}"
+                currentBuild.currentResult = 'FAILURE'
             } finally {
                 
                 if (notificationChannel) {

--- a/vars/sfdxBuildPipeline.groovy
+++ b/vars/sfdxBuildPipeline.groovy
@@ -190,8 +190,7 @@ def call(Map parameters = [:]) {
                     junit keepLongStdio: true, testResults: 'tests/**/*-junit.xml'
                 }
             } catch (error) {
-                currentBuild.result = 'FAILURE'
-                println("Error: ${error}")
+                echo "Error: ${error}"
             } finally {
                 
                 if (notificationChannel) {


### PR DESCRIPTION
Reverting temporarily the try/catch because it's causing some cast issues.
`hudson.remoting.ProxyException: org.codehaus.groovy.runtime.typehandling.GroovyCastException: Cannot cast object '{default=null}' with class 'java.util.HashMap' to class 'org.jenkinsci.plugins.pipeline.modeldefinition.model.Root' due to: groovy.lang.GroovyRuntimeException: Could not find matching constructor for: org.jenkinsci.plugins.pipeline.modeldefinition.model.Root(java.util.HashMap)`