### PR TITLE
bug/#103

### DIFF
--- a/vars/sfdxBuildPipeline.groovy
+++ b/vars/sfdxBuildPipeline.groovy
@@ -72,7 +72,7 @@ def call(Map parameters = [:]) {
             }
             
             /**
-             * Using the try/catch block to ensure a safe cleanup, perform notifications 
+             * Using the catchError to ensure a safe cleanup, perform notifications 
              * and execute a final stage (optional)
              */
             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {

--- a/vars/sfdxBuildPipeline.groovy
+++ b/vars/sfdxBuildPipeline.groovy
@@ -188,7 +188,9 @@ def call(Map parameters = [:]) {
 
             stage("publish") {
                 echo "Publishing test results"
-                junit keepLongStdio: true, testResults: 'tests/**/*-junit.xml'
+                catchError(stageResult: 'FAILURE') {
+                    junit keepLongStdio: true, testResults: 'tests/**/*-junit.xml'
+                }
             }
             
             if (notificationChannel) {

--- a/vars/sfdxBuildPipeline.groovy
+++ b/vars/sfdxBuildPipeline.groovy
@@ -59,14 +59,12 @@ def call(Map parameters = [:]) {
                         user = env.BUILD_USER ? "${env.BUILD_USER}" : "timer"
                         userMailTo = env.BUILD_USER_ID ? "[<mailto:${env.BUILD_USER_EMAIL}|${env.BUILD_USER_ID}>]" : ""
                     }
-                    try {
+                    catchError(stageResult: 'FAILURE') {
                         slackSend(
                             channel: "${notificationChannel}",
                             color: 'good',
                             message: "${decodedJobName} - #${env.BUILD_NUMBER} Started by ${user} ${userMailTo} (<${env.BUILD_URL}|Open>)"
                         )
-                    } catch (error) {
-                        echo "Error: ${error.getMessage()}"
                     }
                 }
             }
@@ -211,14 +209,12 @@ def call(Map parameters = [:]) {
                         // FAILED OR ABORTED
                         slackNotificationColor = 'danger'
                     }
-                    try {
+                    catchError(stageResult: 'FAILURE') {
                         slackSend(
                             channel: "${notificationChannel}",
                             color: "${slackNotificationColor}",
                             message: "${decodedJobName} - #${env.BUILD_NUMBER} - ${currentBuild.currentResult} after ${currentBuild.durationString.minus(' and counting')} (<${env.BUILD_URL}|Open>)"
                         )
-                    } catch (error) {
-                        echo "Error: ${error.getMessage()}"
                     }
                 }
             }

--- a/vars/sfdxBuildPipeline.groovy
+++ b/vars/sfdxBuildPipeline.groovy
@@ -172,6 +172,9 @@ def call(Map parameters = [:]) {
                                 afterTestStage org
                             }
                         }
+                    } catch (error) {
+                        echo "Error: ${error}"
+                        throw error
                     } finally {
                         stage("${org.name} delete") {
                             if (keepOrg) {
@@ -183,21 +186,18 @@ def call(Map parameters = [:]) {
                             }
                         }
                     }
-                }
-            } catch (error) {
-                echo "Error: ${error}"
-            } finally {
-                
-                try {
-                    stage("publish") {
+
+                        stage("publish") {
                         echo "Publishing test results"
                         junit keepLongStdio: true, testResults: 'tests/**/*-junit.xml'
                     }
-                } catch (error) {
-                    echo "Error (message): ${error.getMessage()}"
-                    echo "Error (toString): ${error.toString()}"
                 }
-
+            } catch (error) {
+                echo "Error: ${error}"
+                currentBuild.result = 'FAILED'
+                throw error
+            } finally {
+                
                 if (notificationChannel) {
                     stage("slack notification end") {
                         

--- a/vars/sfdxBuildPipeline.groovy
+++ b/vars/sfdxBuildPipeline.groovy
@@ -75,7 +75,7 @@ def call(Map parameters = [:]) {
              * Using the try/catch block to ensure a safe cleanup, perform notifications 
              * and execute a final stage (optional)
              */
-            // try {
+            try {
                 def propertiesConfigured = []
                 propertiesConfigured.push(
                     buildDiscarder(
@@ -184,13 +184,20 @@ def call(Map parameters = [:]) {
                         }
                     }
                 }
-            // } finally {
-
-                stage("publish") {
-                    echo "Publishing test results"
-                    junit keepLongStdio: true, testResults: 'tests/**/*-junit.xml'
-                }
+            } catch (error) {
+                echo "Error: ${error}"
+            } finally {
                 
+                try {
+                    stage("publish") {
+                        echo "Publishing test results"
+                        junit keepLongStdio: true, testResults: 'tests/**/*-junit.xml'
+                    }
+                } catch (error) {
+                    echo "Error (message): ${error.getMessage()}"
+                    echo "Error (toString): ${error.toString()}"
+                }
+
                 if (notificationChannel) {
                     stage("slack notification end") {
                         
@@ -238,7 +245,7 @@ def call(Map parameters = [:]) {
                         finalStage.call()
                     }
                 }
-            // }
+            }
         }
     }
 }


### PR DESCRIPTION
Related to the **sfdxBuildPipeline - steps not executed in case of failure** #103
Using the **catchError** approach instead of **try/catch/finally** to avoid the errors below:

> hudson.remoting.ProxyException: org.codehaus.groovy.runtime.typehandling.GroovyCastException: Cannot cast object 'hudson.tasks.junit.TestResultSummary@xxxxxxx' with class 'hudson.tasks.junit.TestResultSummary' ...

OR

> hudson.remoting.ProxyException: org.codehaus.groovy.runtime.typehandling.GroovyCastException: Cannot cast object '{default=null}' with class 'java.util.HashMap' to class 'org.jenkinsci.plugins.pipeline.modeldefinition.model.Root' due to: groovy.lang.GroovyRuntimeException: Could not find matching constructor for: org.jenkinsci.plugins.pipeline.modeldefinition.model.Root(java.util.HashMap)

`


![image](https://user-images.githubusercontent.com/8863913/109313557-440ee900-7840-11eb-8278-102c1d10f79a.png)